### PR TITLE
Allow computercss to be spawned in any way.

### DIFF
--- a/lua/entities/sent_computercss.lua
+++ b/lua/entities/sent_computercss.lua
@@ -16,8 +16,7 @@ AddCSLuaFile()
     
 	function ENT:SpawnFunction(ply, trace, client)
         if !IsMounted("cstrike") then
-            ply:PrintMessage( HUD_PRINTTALK, "Server don't have CSS content!" )
-            return false;
+            ply:PrintMessage( HUD_PRINTTALK, "You need CSS content!" )
         end
 		if (!trace.Hit) then
 			return false;


### PR DESCRIPTION
The point is that some players have CSS content without the game itself.
Probably it will not be mounted (as in my case). So instead of disallowing spawning an entity, it will just display a warning